### PR TITLE
Move BovineLabs menu item to Window menu

### DIFF
--- a/BovineLabs.Analyzers/UI/AnalyzersWindow.cs
+++ b/BovineLabs.Analyzers/UI/AnalyzersWindow.cs
@@ -17,7 +17,7 @@ namespace BovineLabs.Analyzers.UI
         private const string DisposableDirectory = Packages + "RoslynAnalyzers/DisposableAnalyzers/";
         private const string UIDirectory = Packages + "BovineLabs.Analyzers/UI/";
 
-        [MenuItem("BovineLabs/Tools/Analyzers", priority = 1005)]
+        [MenuItem("Window/BovineLabs/Tools/Analyzers", priority = 1005)]
         private static void ShowWindow()
         {
             var window = GetWindow<AnalyzersWindow>();


### PR DESCRIPTION
I'm proposing this change because my Unity menu bar is getting quite crowded, and most maintained projects have moved their menu items to the Window menu. In fact, the Readme even says this is the expected behavior:
>A  simple UI interface is available at **Windows/BovineLabs/Analyzers**. This allows you change the target directory for the analyzers.

But the actual menu item is added to the root, visible here:
![image](https://user-images.githubusercontent.com/4650220/162592755-57697dea-b671-4086-aef1-4cc2dec290e9.png)

This PR moves the menu item to the Window menu:
![image](https://user-images.githubusercontent.com/4650220/162592734-c6afe972-dad5-4b3a-86b9-1d8e8cd4b616.png)
